### PR TITLE
use subtitel for last sync value to allow longer translations

### DIFF
--- a/UBsync-ui/ui/SyncServicePage.qml
+++ b/UBsync-ui/ui/SyncServicePage.qml
@@ -57,7 +57,8 @@ Page {
                 ListItem {
                     ListItemLayout {
                         property string lastSyncTime: daemonController.lastSync ? timeSince(daemonController.lastSync) : owncloud.settings.lastSync ? timeSince(owncloud.settings.lastSync) : i18n.tr("Sync Required")
-                        title.text: i18n.tr("Last Sync: ") +  lastSyncTime
+                        title.text: i18n.tr("Last Sync:")
+                        subtitle.text: lastSyncTime
                         anchors{verticalCenter: parent.verticalCenter}
 
                         Button{


### PR DESCRIPTION
Long translations will not fit the content into one line. The actual value of the last sync will get cut of. So why not use subtitle to show that value? Seems to be the easiest solution I can think of.

Note: not sure if we then should do the same for status, just for consistency.

![screenshot20211202_233349159](https://user-images.githubusercontent.com/37637312/144514682-386c0ef0-5335-4617-a4c9-3615599d57ec.png)
