### PR TITLE
rearrange buttons and make ok green (=positive)

### DIFF
--- a/UBsync-ui/components/FileBrowser.qml
+++ b/UBsync-ui/components/FileBrowser.qml
@@ -137,23 +137,22 @@ Page {
             }
 
             Button {
-                text: i18n.tr("Cancel")
-                onClicked: PopupUtils.close(dialogue)
-            }
-            Button {
                 id: okButton
                 text: i18n.tr("OK")
                 enabled: folderName.text
-                color: UbuntuColors.orange
+                color: theme.palette.normal.positive
                 onClicked: {
                     folderListModel.newFolder(currentPath + "/" + folderName.text)
                     PopupUtils.close(dialogue)
                 }
+            }
+
+            Button {
+                text: i18n.tr("Cancel")
+                onClicked: PopupUtils.close(dialogue)
             }
         }
     }
 
 
 }
-
-


### PR DESCRIPTION
In the "create folder" dialog I think the ok button should be on top since that is the most common action. Also it should be green because it is a positive action, a confirmation.

With this PR the dialog will look like this:

![grafik](https://user-images.githubusercontent.com/37637312/144637919-82400851-bf0b-4576-953d-85968f905a16.png)
