### PR TITLE
Draft: rework link strings so the link text is translatable

### DIFF
--- a/UBsync-ui/components/LabelLinkRow.qml
+++ b/UBsync-ui/components/LabelLinkRow.qml
@@ -1,0 +1,27 @@
+import QtQuick 2.4
+import Ubuntu.Components 1.3
+
+Row {
+    property string labeltext
+    property string linktext
+    property string linkurl
+
+    spacing: units.gu(1)
+    anchors.horizontalCenter: parent.horizontalCenter
+
+    Label {
+        id: label
+        text: labeltext
+        wrapMode: Text.WordWrap
+    }
+    Label {
+        id: linklabel
+        text: linktext
+        wrapMode: Text.WordWrap
+        color: theme.palette.normal.activity
+        MouseArea {
+            anchors.fill: parent
+            onClicked: Qt.openUrlExternally(linkurl)
+        }
+    }
+}

--- a/UBsync-ui/ui/AboutPage.qml
+++ b/UBsync-ui/ui/AboutPage.qml
@@ -1,5 +1,6 @@
 import QtQuick 2.4
 import Ubuntu.Components 1.3
+import "../components"
 
 Page {
     id: aboutPage
@@ -55,35 +56,41 @@ Page {
                 width: parent.width
 
                 Label {
+                    id: appVersionLabel
                     width: parent.width
                     horizontalAlignment: Text.AlignHCenter
                     // TRANSLATORS: Owncloud Sync version number e.g Version 0.1
                     text: i18n.tr("App Version %1").arg(Qt.application.version)
                 }
                 Label{
+                    id: clientLabel
                     width: parent.width
                     horizontalAlignment: Text.AlignHCenter
                     // TRANSLATORS: Nextcloudcmd binary version number e.g Version 1.8.1
                     text: i18n.tr("Client: %1").arg(owncloud.settings.owncloudcmdVersion)
                 }
-                Label {
+                LabelLinkRow {
+                    id: maintainerLabel
                     width: parent.width
-                    horizontalAlignment: Text.AlignHCenter
-                    text: i18n.tr("Maintained by %1").arg("Jan") + " " + i18n.tr("and by the %1").arg("<a href=\"https://github.com/belohoub/UBsync\">UBsync team</a>")
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    // TRANSLATORS: %1 is the maintainers name, %2 is the link text to the UBsync contributors teams page
+                    labeltext: i18n.tr("Maintained by %1 and the").arg("Jan")
+                    linktext: i18n.tr("UBsync team")
+                    linkurl: "https://github.com/belohoub/UBsync"
                 }
-
                 Label {
                     width: parent.width
                     horizontalAlignment: Text.AlignHCenter
                     text: " "
                 }
-                 Label {
+                LabelLinkRow {
+                    id: issueReportLabel
                     width: parent.width
-                    horizontalAlignment: Text.AlignHCenter
-                    wrapMode: Text.WordWrap
-                    text: i18n.tr("Please report bugs to the %1").arg("<a href=\"https://github.com/belohoub/UBsync/issues\">issue tracker</a>")
-                    onLinkActivated: Qt.openUrlExternally(link)
-                 }
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    labeltext: i18n.tr("Please report bugs to the")
+                    linktext: i18n.tr("issue tracker")
+                    linkurl: "https://github.com/belohoub/UBsync/issues"
+                }
             }
 
             Column {
@@ -100,42 +107,45 @@ Page {
                     text: i18n.tr("Thanks to")
                 }
 
-                Label {
+                LabelLinkRow {
+                    id: ownCloudClientLabel
                     width: parent.width
-                    wrapMode: Text.WordWrap
-                    horizontalAlignment: Text.AlignHCenter
-                    text: i18n.tr("Owncloud client: %1".arg("<a href=\"https://doc.owncloud.org/desktop/2.3/owncloudcmd.1.html\">Owncloudcmd</a>"))
-                    onLinkActivated: Qt.openUrlExternally(link)
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    labeltext: i18n.tr("Owncloud client:")
+                    linktext: "Owncloudcmd"
+                    linkurl: "https://doc.owncloud.org/desktop/2.3/owncloudcmd.1.html"
                 }
-                Label {
+                LabelLinkRow {
+                    id: nextCloudClientLabel
                     width: parent.width
-                    wrapMode: Text.WordWrap
-                    horizontalAlignment: Text.AlignHCenter
-                    text: i18n.tr("Nextcloud client: %1".arg("<a href=\"https://docs.nextcloud.com/desktop/2.3/advancedusage.html\">Nextcloudcmd</a>"))
-                    onLinkActivated: Qt.openUrlExternally(link)
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    labeltext: i18n.tr("Nextcloud client:")
+                    linktext: "Nextcloudcmd"
+                    linkurl: "https://docs.nextcloud.com/desktop/2.3/advancedusage.html"
                 }
-
-
-                Label {
+                LabelLinkRow {
+                    id: qtLabel
                     width: parent.width
-                    wrapMode: Text.WordWrap
-                    horizontalAlignment: Text.AlignHCenter
-                    text: i18n.tr("%1, a Qt library for WebDAV".arg("<a href=\"https://github.com/mhaller/qwebdavlib\">qwebdavlib</a>"))
-                    onLinkActivated: Qt.openUrlExternally(link)
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    labeltext: i18n.tr("This Qt library for WebDAV:")
+                    linktext: "qwebdavlib"
+                    linkurl: "https://github.com/mhaller/qwebdavlib"
                 }
-                Label {
+                LabelLinkRow {
+                    id: iconLabel
                     width: parent.width
-                    wrapMode: Text.WordWrap
-                    horizontalAlignment: Text.AlignHCenter
-                    text: i18n.tr("Joan CiberSheep for the %1 logo".arg("<a href=\"https://github.com/snwh/suru-icon-theme\">Suru Theme</a>"))
-                    onLinkActivated: Qt.openUrlExternally(link)
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    labeltext: i18n.tr("Joan CiberSheep for the logo from:")
+                    linktext: "Suru Theme"
+                    linkurl: "https://github.com/snwh/suru-icon-theme"
                 }
-                Label {
+                LabelLinkRow {
+                    id: clickableLabel
                     width: parent.width
-                    wrapMode: Text.WordWrap
-                    horizontalAlignment: Text.AlignHCenter
-                    text: i18n.tr("Lukas to enable the application with %1".arg("<a href=\"http://clickable.bhdouglass.com/en/latest/index.html\">Clickable</a>"))
-                    onLinkActivated: Qt.openUrlExternally(link)
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    labeltext: i18n.tr("Lukas to enable the application with:")
+                    linktext: "Clickable"
+                    linkurl: "https://clickable-ut.dev/en/latest/index.html"
                 }
             }
             Label {
@@ -145,21 +155,21 @@ Page {
                 horizontalAlignment: Text.AlignHCenter
                 text: i18n.tr("Released under the terms of the GNU GPL v3")
             }
-            Label {
+            LabelLinkRow {
+                id: forkLabel
                 width: parent.width
-                wrapMode: Text.WordWrap
-                textSize: Label.Small
-                horizontalAlignment: Text.AlignHCenter
-                text: i18n.tr("Fork of %1".arg("<a href=\"https://launchpad.net/owncloud-sync\">Owncloud-Sync</a>"))
-                onLinkActivated: Qt.openUrlExternally(link)
+                anchors.horizontalCenter: parent.horizontalCenter
+                labeltext: i18n.tr("Fork of:")
+                linktext: "Owncloud-Sync"
+                linkurl: "https://launchpad.net/owncloud-sync"
             }
-            Label {
+            LabelLinkRow {
+                id: sourceCodeLabel
                 width: parent.width
-                wrapMode: Text.WordWrap
-                textSize: Label.Small
-                horizontalAlignment: Text.AlignHCenter
-                text: i18n.tr("Source code available on %1").arg("<a href=\"https://github.com/belohoub/UBsync\">github.com/belohoub/UBsync</a>")
-                onLinkActivated: Qt.openUrlExternally(link)
+                anchors.horizontalCenter: parent.horizontalCenter
+                labeltext: i18n.tr("Source code available on:")
+                linktext: "github.com/belohoub/UBsync"
+                linkurl: "https://github.com/belohoub/UBsync"
             }
         }
     }

--- a/po/ubsync.pot
+++ b/po/ubsync.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-12-03 06:44+0000\n"
+"POT-Creation-Date: 2021-12-03 22:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,532 +18,558 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/components/FileBrowser.qml:69
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/components/FileBrowser.qml:69
+#: /media/Daten/Forks/UBsync/UBsync-ui/components/FileBrowser.qml:70
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/components/FileBrowser.qml:70
 msgid "No folders, press"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/components/FileBrowser.qml:82
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/components/FileBrowser.qml:82
-msgid "on the panel to select this folder"
+#: /media/Daten/Forks/UBsync/UBsync-ui/components/FileBrowser.qml:84
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/components/FileBrowser.qml:84
+msgid "on the panel to select this folder, or press"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/components/FileBrowser.qml:129
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/components/FileBrowser.qml:129
+#: /media/Daten/Forks/UBsync/UBsync-ui/components/FileBrowser.qml:99
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/components/FileBrowser.qml:99
+msgid "to create a new folder."
+msgstr ""
+
+#: /media/Daten/Forks/UBsync/UBsync-ui/components/FileBrowser.qml:146
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/components/FileBrowser.qml:146
 msgid "Create New Folder"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/components/FileBrowser.qml:133
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/components/FileBrowser.qml:133
+#: /media/Daten/Forks/UBsync/UBsync-ui/components/FileBrowser.qml:150
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/components/FileBrowser.qml:150
 msgid "New Folder"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/components/FileBrowser.qml:140
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/components/FileBrowser.qml:140
-msgid "Cancel"
-msgstr ""
-
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/components/FileBrowser.qml:145
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/components/FileBrowser.qml:145
+#: /media/Daten/Forks/UBsync/UBsync-ui/components/FileBrowser.qml:158
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/components/FileBrowser.qml:158
 msgid "OK"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/AboutPage.qml:10
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/TargetsPage.qml:171
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/AboutPage.qml:10
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/TargetsPage.qml:171
+#: /media/Daten/Forks/UBsync/UBsync-ui/components/FileBrowser.qml:168
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/components/FileBrowser.qml:168
+msgid "Cancel"
+msgstr ""
+
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/AboutPage.qml:11
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/TargetsPage.qml:171
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/AboutPage.qml:11
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/TargetsPage.qml:171
 msgid "About"
 msgstr ""
 
 #. TRANSLATORS: Owncloud Sync version number e.g Version 0.1
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/AboutPage.qml:61
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/AboutPage.qml:61
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/AboutPage.qml:63
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/AboutPage.qml:62
 #, qt-format
 msgid "App Version %1"
 msgstr ""
 
 #. TRANSLATORS: Nextcloudcmd binary version number e.g Version 1.8.1
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/AboutPage.qml:67
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/AboutPage.qml:67
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/AboutPage.qml:70
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/AboutPage.qml:68
 #, qt-format
 msgid "Client: %1"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/AboutPage.qml:72
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/AboutPage.qml:72
+#. TRANSLATORS: %1 is the maintainers name, %2 is the link text to the UBsync contributors teams page
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/AboutPage.qml:77
 #, qt-format
-msgid "Maintained by %1"
+msgid "Maintained by %1 and the"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/AboutPage.qml:72
-#, qt-format
-msgid "and by the %1"
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/AboutPage.qml:78
+msgid "UBsync team"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/AboutPage.qml:78
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/AboutPage.qml:78
-msgid " "
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/AboutPage.qml:90
+msgid "Please report bugs to the"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/AboutPage.qml:84
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/AboutPage.qml:84
-#, qt-format
-msgid "Please report bugs to the %1"
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/AboutPage.qml:91
+msgid "issue tracker"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/AboutPage.qml:100
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/AboutPage.qml:107
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/AboutPage.qml:107
 msgid "Thanks to"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/AboutPage.qml:107
-#, qt-format
-msgid "Owncloud client: %1"
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/AboutPage.qml:114
+msgid "Owncloud client:"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/AboutPage.qml:114
-#, qt-format
-msgid "Nextcloud client: %1"
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/AboutPage.qml:122
+msgid "Nextcloud client:"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/AboutPage.qml:123
-#, qt-format
-msgid "%1, a Qt library for WebDAV"
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/AboutPage.qml:130
+msgid "This Qt library for WebDAV:"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/AboutPage.qml:130
-#, qt-format
-msgid "Joan CiberSheep for the %1 logo"
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/AboutPage.qml:138
+msgid "Joan CiberSheep for the logo from:"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/AboutPage.qml:137
-#, qt-format
-msgid "Lukas to enable the application with %1"
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/AboutPage.qml:146
+msgid "Lukas to enable the application with:"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/AboutPage.qml:146
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/AboutPage.qml:146
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/AboutPage.qml:156
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/AboutPage.qml:153
 msgid "Released under the terms of the GNU GPL v3"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/AboutPage.qml:153
-#, qt-format
-msgid "Fork of %1"
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/AboutPage.qml:162
+msgid "Fork of:"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/AboutPage.qml:161
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/AboutPage.qml:161
-#, qt-format
-msgid "Source code available on %1"
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/AboutPage.qml:170
+msgid "Source code available on:"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/AccountsPage.qml:127
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/AccountsPage.qml:127
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/AccountsPage.qml:127
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/AccountsPage.qml:127
 msgid "Online Accounts"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/AccountsPage.qml:237
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/AccountsPage.qml:237
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/AccountsPage.qml:237
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/AccountsPage.qml:237
 msgid "No accounts, press"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/AccountsPage.qml:252
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/AccountsPage.qml:252
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/AccountsPage.qml:252
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/AccountsPage.qml:252
 msgid "on the panel to add a new account"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/EditAccount.qml:79
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/HelpPage.qml:125
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/EditAccount.qml:79
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/HelpPage.qml:125
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/EditAccount.qml:79
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/HelpPage.qml:128
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/EditAccount.qml:79
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/HelpPage.qml:128
 msgid "Not Configured Account"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/EditAccount.qml:79
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/EditAccount.qml:84
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/HelpPage.qml:125
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/HelpPage.qml:159
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/EditAccount.qml:79
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/EditAccount.qml:84
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/HelpPage.qml:125
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/HelpPage.qml:159
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/EditAccount.qml:79
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/EditAccount.qml:84
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/HelpPage.qml:128
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/HelpPage.qml:164
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/EditAccount.qml:79
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/EditAccount.qml:84
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/HelpPage.qml:128
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/HelpPage.qml:164
 msgid "related targets will NOT sync"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/EditAccount.qml:84
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/HelpPage.qml:159
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/EditAccount.qml:84
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/HelpPage.qml:159
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/EditAccount.qml:84
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/HelpPage.qml:164
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/EditAccount.qml:84
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/HelpPage.qml:164
 msgid "Disabled Account"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/EditAccount.qml:90
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/HelpPage.qml:91
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/EditAccount.qml:90
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/HelpPage.qml:91
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/EditAccount.qml:90
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/HelpPage.qml:91
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/EditAccount.qml:90
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/HelpPage.qml:91
 msgid "Enabled Account"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/EditAccount.qml:90
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/HelpPage.qml:91
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/EditAccount.qml:90
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/HelpPage.qml:91
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/EditAccount.qml:90
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/HelpPage.qml:91
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/EditAccount.qml:90
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/HelpPage.qml:91
 msgid "related targets will sync"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/EditAccount.qml:172
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/EditAccount.qml:172
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/EditAccount.qml:172
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/EditAccount.qml:172
 msgid "Account Settings"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/EditAccount.qml:179
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/EditAccount.qml:179
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/EditAccount.qml:179
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/EditAccount.qml:179
 msgid "New Target"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/EditAccount.qml:377
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/EditAccount.qml:377
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/EditAccount.qml:377
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/EditAccount.qml:377
 msgid "Sync on Mobile Data"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/EditAccount.qml:409
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/EditAccount.qml:409
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/EditAccount.qml:409
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/EditAccount.qml:409
 msgid "Sync hidden files"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/EditAccount.qml:441
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/EditAccount.qml:441
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/EditAccount.qml:441
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/EditAccount.qml:441
 msgid "Sync Frequency"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/EditAccount.qml:462
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/EditAccount.qml:462
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/EditAccount.qml:462
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/EditAccount.qml:462
 msgid "No Sync"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/EditAccount.qml:462
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/EditAccount.qml:462
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/EditAccount.qml:462
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/EditAccount.qml:462
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/EditAccount.qml:529
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/EditTarget.qml:579
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/EditAccount.qml:529
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/EditTarget.qml:579
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/EditAccount.qml:529
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/EditTarget.qml:579
 msgid ""
 "Synchronization service not running! Please, go to UBsync Settings and start "
 "the sync service, otherwise the target synchronization will not begin."
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/EditTarget.qml:37
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/EditTarget.qml:37
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/EditTarget.qml:37
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/EditTarget.qml:37
 msgid "Account Disabled"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/EditTarget.qml:37
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/EditTarget.qml:43
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/EditTarget.qml:48
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/HelpPage.qml:256
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/HelpPage.qml:293
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/EditTarget.qml:37
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/EditTarget.qml:43
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/EditTarget.qml:48
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/HelpPage.qml:256
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/HelpPage.qml:293
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/EditTarget.qml:37
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/EditTarget.qml:43
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/EditTarget.qml:48
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/HelpPage.qml:263
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/HelpPage.qml:300
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/EditTarget.qml:37
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/EditTarget.qml:43
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/EditTarget.qml:48
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/HelpPage.qml:263
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/HelpPage.qml:300
 msgid "target will NOT sync"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/EditTarget.qml:40
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/EditTarget.qml:43
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/EditTarget.qml:40
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/EditTarget.qml:43
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/EditTarget.qml:40
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/EditTarget.qml:43
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/EditTarget.qml:40
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/EditTarget.qml:43
 msgid "Account Not Configured"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/EditTarget.qml:48
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/EditTarget.qml:48
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/EditTarget.qml:48
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/EditTarget.qml:48
 msgid "Target Disabled"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/EditTarget.qml:53
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/EditTarget.qml:53
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/EditTarget.qml:53
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/EditTarget.qml:53
 msgid "Target Enabled"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/EditTarget.qml:53
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/HelpPage.qml:220
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/EditTarget.qml:53
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/HelpPage.qml:220
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/EditTarget.qml:53
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/HelpPage.qml:227
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/EditTarget.qml:53
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/HelpPage.qml:227
 msgid "target will sync"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/EditTarget.qml:236
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/EditTarget.qml:236
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/EditTarget.qml:236
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/EditTarget.qml:236
 msgid "Target Settings"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/EditTarget.qml:400
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/TargetsPage.qml:46
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/TargetsPage.qml:46
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/EditTarget.qml:400
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/TargetsPage.qml:46
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/EditTarget.qml:400
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/TargetsPage.qml:46
 msgid "Unknown Account"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/EditTarget.qml:522
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/EditTarget.qml:522
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/EditTarget.qml:522
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/EditTarget.qml:522
 msgid "Enable/Disable this Target"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/HelpPage.qml:8
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/TargetsPage.qml:177
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/HelpPage.qml:8
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/TargetsPage.qml:177
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/HelpPage.qml:8
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/TargetsPage.qml:177
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/HelpPage.qml:8
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/TargetsPage.qml:177
 msgid "Help"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/HelpPage.qml:29
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/HelpPage.qml:29
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/HelpPage.qml:29
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/HelpPage.qml:29
 msgid "<p>To set-up synchronization for your folders:</p>"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/HelpPage.qml:42
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/TargetsPage.qml:189
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/HelpPage.qml:42
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/TargetsPage.qml:189
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/HelpPage.qml:42
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/TargetsPage.qml:189
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/HelpPage.qml:42
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/TargetsPage.qml:189
 msgid "Accounts"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/HelpPage.qml:54
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/HelpPage.qml:54
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/HelpPage.qml:54
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/HelpPage.qml:54
 msgid "<p>UBsync uses following account symbols to express account states:</p>"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/HelpPage.qml:172
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/HelpPage.qml:172
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/HelpPage.qml:179
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/HelpPage.qml:179
 msgid "Targets"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/HelpPage.qml:183
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/HelpPage.qml:183
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/HelpPage.qml:190
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/HelpPage.qml:190
 msgid ""
 "<p>The term \"target\" represents in the UBsync context the remote/local "
 "directory pair intended for synchronization plus  the set of custom \"target"
 "\" configuration.</p>"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/HelpPage.qml:183
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/HelpPage.qml:183
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/HelpPage.qml:190
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/HelpPage.qml:190
 msgid "<p>UBsync uses following target symbols to express target states:</p>"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/HelpPage.qml:220
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/HelpPage.qml:220
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/HelpPage.qml:227
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/HelpPage.qml:227
 msgid "Active Target"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/HelpPage.qml:256
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/HelpPage.qml:256
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/HelpPage.qml:263
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/HelpPage.qml:263
 msgid "Inactive Target"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/HelpPage.qml:293
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/HelpPage.qml:293
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/HelpPage.qml:300
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/HelpPage.qml:300
 msgid "Target With Disabled/Not Configured Account"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/HelpPage.qml:51
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/HelpPage.qml:51
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/HelpPage.qml:51
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/HelpPage.qml:51
 msgid ""
 "<p>The term \"account\" represents in the UBsync context the system online "
 "account, as configured in system settings plus the custom UBsync "
 "configuration maintained by UBsync.</p>"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/RequestAccountPage.qml:13
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/RequestAccountPage.qml:13
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/RequestAccountPage.qml:13
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/RequestAccountPage.qml:13
 msgid "Add Online Account"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/RequestAccountPage.qml:22
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/RequestAccountPage.qml:22
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/RequestAccountPage.qml:22
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/RequestAccountPage.qml:22
 msgid "Add NextCloud account"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/RequestAccountPage.qml:35
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/RequestAccountPage.qml:35
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/RequestAccountPage.qml:35
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/RequestAccountPage.qml:35
 msgid "Add OwnCloud account"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/SyncServicePage.qml:10
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/SyncServicePage.qml:10
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/SyncServicePage.qml:10
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/SyncServicePage.qml:10
 msgid "Sync Service"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/SyncServicePage.qml:38
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/SyncServicePage.qml:38
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/SyncServicePage.qml:38
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/SyncServicePage.qml:38
 #, qt-format
 msgid "Status: %1"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/SyncServicePage.qml:38
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/SyncServicePage.qml:38
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/SyncServicePage.qml:38
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/SyncServicePage.qml:38
 msgid "Syncing"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/SyncServicePage.qml:38
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/SyncServicePage.qml:38
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/SyncServicePage.qml:38
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/SyncServicePage.qml:38
 msgid "Idle"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/SyncServicePage.qml:38
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/SyncServicePage.qml:38
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/SyncServicePage.qml:38
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/SyncServicePage.qml:38
 msgid "Stopped"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/SyncServicePage.qml:43
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/SyncServicePage.qml:43
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/SyncServicePage.qml:43
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/SyncServicePage.qml:43
 msgid "Stop"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/SyncServicePage.qml:43
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/SyncServicePage.qml:43
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/SyncServicePage.qml:43
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/SyncServicePage.qml:43
 msgid "Start"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/SyncServicePage.qml:49
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/SyncServicePage.qml:49
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/SyncServicePage.qml:49
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/SyncServicePage.qml:49
 msgid "Stop Service"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/SyncServicePage.qml:49
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/SyncServicePage.qml:49
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/SyncServicePage.qml:49
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/SyncServicePage.qml:49
 msgid "Start Service"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/SyncServicePage.qml:59
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/SyncServicePage.qml:59
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/SyncServicePage.qml:59
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/SyncServicePage.qml:59
 msgid "Sync Required"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/SyncServicePage.qml:60
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/SyncServicePage.qml:60
-msgid "Last Sync: "
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/SyncServicePage.qml:60
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/SyncServicePage.qml:60
+msgid "Last Sync:"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/SyncServicePage.qml:64
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/SyncServicePage.qml:64
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/SyncServicePage.qml:65
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/SyncServicePage.qml:65
 msgid "Sync"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/SyncServicePage.qml:72
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/SyncServicePage.qml:72
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/SyncServicePage.qml:73
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/SyncServicePage.qml:73
 msgid "Sync Starting"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/SyncServicePage.qml:85
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/SyncServicePage.qml:85
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/SyncServicePage.qml:86
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/SyncServicePage.qml:86
 #, qt-format
 msgid "Client : %1"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/SyncServicePage.qml:96
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/SyncServicePage.qml:96
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/SyncServicePage.qml:97
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/SyncServicePage.qml:97
 #, qt-format
 msgid "Service : %1"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/SyncServicePage.qml:115
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/SyncServicePage.qml:115
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/SyncServicePage.qml:116
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/SyncServicePage.qml:116
 msgid "Never"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/SyncServicePage.qml:119
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/SyncServicePage.qml:120
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/SyncServicePage.qml:120
 #, qt-format
 msgid "%1 Months Ago"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/SyncServicePage.qml:123
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/SyncServicePage.qml:124
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/SyncServicePage.qml:124
 #, qt-format
 msgid "%1 Days Ago"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/SyncServicePage.qml:127
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/SyncServicePage.qml:128
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/SyncServicePage.qml:128
 #, qt-format
 msgid "%1  Hours Ago"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/SyncServicePage.qml:131
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/SyncServicePage.qml:132
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/SyncServicePage.qml:132
 #, qt-format
 msgid "%1 Minutes Ago"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/SyncServicePage.qml:134
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/SyncServicePage.qml:134
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/SyncServicePage.qml:135
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/SyncServicePage.qml:135
 msgid "A Minute Ago"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/SyncServicePage.qml:138
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/SyncServicePage.qml:139
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/SyncServicePage.qml:139
 #, qt-format
 msgid "%1 Seconds Ago"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/SyncServicePage.qml:141
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/SyncServicePage.qml:141
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/SyncServicePage.qml:142
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/SyncServicePage.qml:142
 msgid "Just Now"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/TargetsPage.qml:165
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/TargetsPage.qml:165
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/TargetsPage.qml:165
 msgid "Sync Targets"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/TargetsPage.qml:183
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/TargetsPage.qml:183
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/TargetsPage.qml:183
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/TargetsPage.qml:183
 msgid "Settings"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/TargetsPage.qml:208
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/TargetsPage.qml:208
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/TargetsPage.qml:208
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/TargetsPage.qml:208
 msgid "No synchronization targets configured, press"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/TargetsPage.qml:223
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/TargetsPage.qml:223
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/TargetsPage.qml:223
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/TargetsPage.qml:223
 msgid ""
 "in the main panel to enter Account Settings. In Account Settings, create a "
 "new synchronization target from an existing or new account. For explanation, "
 "see the help page."
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/UBsync-ui/ui/WebdavFileBrowser.qml:34
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/WebdavFileBrowser.qml:34
+#: /media/Daten/Forks/UBsync/UBsync-ui/ui/WebdavFileBrowser.qml:34
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/WebdavFileBrowser.qml:34
 msgid "Loading"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/EditAccount.qml:529
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/EditTarget.qml:579
-msgid ""
-"Synchronization service not running! Please, go to UBsync Settings and start "
-"the sync service unless the target synchronization will not begin."
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/AboutPage.qml:73
+#, qt-format
+msgid "Maintained by %1"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/SyncServicePage.qml:119
-msgid " Months Ago"
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/AboutPage.qml:73
+#, qt-format
+msgid "and by the %1"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/SyncServicePage.qml:123
-msgid " Days Ago"
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/AboutPage.qml:85
+#, qt-format
+msgid "Please report bugs to the %1"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/SyncServicePage.qml:127
-msgid "  Hours Ago"
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/AboutPage.qml:114
+#, qt-format
+msgid "Owncloud client: %1"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/SyncServicePage.qml:131
-msgid " Minutes Ago"
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/AboutPage.qml:121
+#, qt-format
+msgid "Nextcloud client: %1"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/build/arm-linux-gnueabihf/app/install/UBsync-ui/ui/SyncServicePage.qml:138
-msgid " Seconds Ago"
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/AboutPage.qml:130
+#, qt-format
+msgid "%1, a Qt library for WebDAV"
 msgstr ""
 
-#: /home/jan/projects/private/ubports/UBsync/build/aarch64-linux-gnu/app/UBsync-ui/UBsync.desktop.h:1
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/AboutPage.qml:137
+#, qt-format
+msgid "Joan CiberSheep for the %1 logo"
+msgstr ""
+
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/AboutPage.qml:144
+#, qt-format
+msgid "Lukas to enable the application with %1"
+msgstr ""
+
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/AboutPage.qml:160
+#, qt-format
+msgid "Fork of %1"
+msgstr ""
+
+#: /media/Daten/Forks/UBsync/build/x86_64-linux-gnu/app/install/UBsync-ui/ui/AboutPage.qml:168
+#, qt-format
+msgid "Source code available on %1"
+msgstr ""
+
+#: /media/Daten/Forks/UBsync/build/aarch64-linux-gnu/app/UBsync-ui/UBsync.desktop.h:1
 msgid "UBsync"
 msgstr ""


### PR DESCRIPTION
So this is my work for tonight. 

Todo:
- maybe get the texts centered horizontally
- apply a similar patch to the multiline texts in the help page

Before:

![grafik](https://user-images.githubusercontent.com/37637312/144682259-fd600a0b-1e1f-4809-89dc-b8ef23d89a12.png)

After:

![grafik](https://user-images.githubusercontent.com/37637312/144682274-97ca5e40-e70b-40d8-8aef-da3a8cf2107a.png)
